### PR TITLE
Temporary fix of anti meridian issue 

### DIFF
--- a/cubedash/static/leaflet-1.7.1/leaflet-src.js
+++ b/cubedash/static/leaflet-1.7.1/leaflet-src.js
@@ -17,6 +17,91 @@
    * Various utility functions, used by Leaflet internally.
    */
 
+  function calculateAntimeridianLat(latLngA, latLngB) {
+    // Ensure that the latitude A is less than latidue B. This will allow the
+    // crossing point to be calculated based on the purportional similarity of
+    // right triangles.
+    if (latLngA.lat > latLngB.lat) {
+      var temp = latLngA;
+      latLngA = latLngB;
+      latLngB = temp;
+    }
+  
+    var A = 360 - Math.abs(latLngA.lng - latLngB.lng);
+    var B = latLngB.lat - latLngA.lat;
+    var a = Math.abs(180 - Math.abs(latLngA.lng));
+  
+    return latLngA.lat + ((B * a) / A);
+  }
+  
+  // @function isCrossAntimeridian(latLngA: LatLng, latLngB: LatLng)
+  // Returns true if the line between the two points will cross either
+  // the prime meridian (Greenwich) or its antimeridian (International Date Line)
+  function isCrossMeridian(latLngA, latLngB) {
+    // Returns true if the signs are not the same.
+    let result =  sign(latLngA.lng) * sign(latLngB.lng) < 0;
+
+    return result
+  }
+  
+  // @function sign(Number)
+  // Returns NaN for non-numbers, 0 for 0, -1 for negative numbers,
+  // 1 for positive numbers
+  function sign(x) {
+    return typeof x === 'number' ? x ? x < 0 ? -1 : 1 : 0 : NaN;
+  }
+  
+  
+  // @function pushLatLng(ring: Point[], projectedBounds: LatLngBounds, latlng: LatLng, map: Map)
+  // Adds the latlng to the current ring as a layer point and expands the projected bounds.
+  function pushLatLng(ring, projectedBounds, latlng, map) {
+    ring.push(map.latLngToLayerPoint(latlng));
+    projectedBounds.extend(ring[ring.length - 1]);
+  }
+  
+  // @function isBreakRing(latLngA: LatLng, latLngB: LatLng)
+  // Determines when the ring should be broken and a new one started.
+  function isBreakRing(latLngA, latLngB) {
+    return isCrossMeridian(latLngA, latLngB)  &&
+    Math.abs(latLngA.lng) > 90 &&
+    Math.abs(latLngB.lng) > 90;
+  }
+  
+  // @function breakRing(currentLat: LatLng, nextLat: LatLng, rings: Point[][],
+  //  projectedBounds: LatLngBounds, map: Map)
+  // Breaks the existing ring along the anti-meridian.
+  // returns the starting latLng for the next ring.
+  function breakRing(currentLat, nextLat, rings, projectedBounds, map) {
+    var ring = rings[rings.length - 1];
+  
+    // Calculate two points for the anti-meridian crossing.
+    var breakLat = calculateAntimeridianLat(currentLat, nextLat);
+    var breakLatLngs = [new L.LatLng(breakLat, 180), new L.LatLng(breakLat, -180)];
+  
+    // Add in first anti-meridian latlng to this ring to finish it.
+    // Positive if positive, negative if negative.
+    if (sign(currentLat.lng) > 0) {
+      pushLatLng(ring, projectedBounds, breakLatLngs.shift(), map);
+    } else {
+      pushLatLng(ring, projectedBounds, breakLatLngs.pop(), map);
+    }
+  
+    // Return the second anti-meridian latlng
+    return breakLatLngs.pop();
+  }
+
+  function wrappedPolyline(latlngs, options) {
+    return new L.Wrapped.Polyline(latlngs, options);
+  }
+  
+  function wrappedPolygon(latlngs, options) {
+    return new L.Wrapped.Polygon(latlngs, options);
+  }
+  
+
+
+
+
   // @function extend(dest: Object, src?: Object): Object
   // Merges the properties of the `src` object (or multiple objects) into `dest` object and returns the latter. Has an `L.extend` shortcut.
   function extend(dest) {
@@ -8456,6 +8541,87 @@
    */
 
   var Polygon = Polyline.extend({
+    // recursively turns latlngs into a set of rings with projected coordinates
+    _projectLatlngs: function (latlngs, result, projectedBounds) {
+      var flat = latlngs[0] instanceof L.LatLng;
+
+      if (flat) {
+        this._createRings(latlngs, result, projectedBounds);
+      } else {
+        for (var i = 0; i < latlngs.length; i++) {
+          this._projectLatlngs(latlngs[i], result, projectedBounds);
+        }
+      }
+    },
+
+    // Creates the rings used to render the latlngs.
+    _createRings: function (latlngs, rings, projectedBounds) {
+      var len = latlngs.length;
+      rings.push([]);
+
+      for (var i = 0; i < len; i++) {
+        // Because this is a polygon, there will always be a comparison latlng
+        var compareLatLng = this._getCompareLatLng(i, len, latlngs);
+
+        pushLatLng(rings[rings.length - 1], projectedBounds, latlngs[i], this._map);
+
+        // Check to see if the ring should be broken.
+        if (isBreakRing(compareLatLng, latlngs[i])) {
+          var secondMeridianLatLng = breakRing(latlngs[i], compareLatLng,
+            rings, projectedBounds, this._map);
+
+          this._startNextRing(rings, projectedBounds, secondMeridianLatLng, i === len - 1);
+        }
+      }
+
+      // Join the last two rings if needed.
+      this._joinLastRing(rings, latlngs);
+    },
+
+    // Starts a new ring if needed and adds the second meridian point to the
+    // correct ring.
+    _startNextRing: function (rings, projectedBounds, secondMeridianLatLng, isLastLatLng) {
+      var ring;
+      if (!isLastLatLng) {
+        ring = [];
+        rings.push(ring);
+        pushLatLng(ring, projectedBounds, secondMeridianLatLng, this._map);
+      } else {
+        // If this is the last latlng, don't bother starting a new ring.
+        // instead, join the last meridian point to the first point, to connect
+        // the shape correctly.
+        ring = rings[0];
+        ring.unshift(this._map.latLngToLayerPoint(secondMeridianLatLng));
+        projectedBounds.extend(ring[0]);
+      }
+    },
+
+    // returns the latlng to compare the current latlng to.
+    _getCompareLatLng: function (i, len, latlngs) {
+      return (i + 1 < len) ? latlngs[i + 1] : latlngs[0];
+    },
+
+    // Joins the last ring to the first if they were accidently disconnected by
+    // crossing the anti-meridian
+    _joinLastRing: function (rings, latlngs) {
+      var firstRing = rings[0];
+      var lastRing = rings[rings.length - 1];
+
+      // check if crosses meridian
+
+      // If both either the first or last latlng cross the meridian immediately, then
+      // they have accidently been split by turning one ring into mulitiple.
+      // Rejoin them.
+      if (rings.length > 1 && (firstRing.length === 2 || lastRing.length === 2) &&
+        !isCrossMeridian(latlngs[0], latlngs[latlngs.length - 1])) {
+        var len = lastRing.length;
+        for (var i = 0; i < len; i++) {
+          firstRing.unshift(lastRing.pop());
+        }
+        // Remove the empty ring.
+        rings.pop();
+      }
+    },
 
   	options: {
   		fill: true

--- a/cubedash/static/overview.js
+++ b/cubedash/static/overview.js
@@ -280,7 +280,15 @@ var OverviewMap = /** @class */ (function (_super) {
 function initPage(hasDisplayableData, showIndividualDatasets, routes, regionData, footprintData, defaultZoom, defaultCenter) {
     var layers = [];
     var activeLayer = null;
-    if (hasDisplayableData) {
+    if (showIndividualDatasets) {
+      layers.push(
+        new DataLayer(
+          "datasets",
+          routes.geojsonDatasetsURL,
+          new DatasetsLayer(routes)
+        )
+      );
+    }
         var footprint = new DataLayer('footprint', routes.geojsonFootprintURL, new FootprintLayer(footprintData, !regionData), footprintData);
         if (regionData) {
             layers.push(new DataLayer('regions', routes.geojsonRegionsURL, new RegionsLayer(regionData, routes), regionData, [footprint]));
@@ -289,10 +297,7 @@ function initPage(hasDisplayableData, showIndividualDatasets, routes, regionData
             layers.push(footprint);
         }
         activeLayer = layers[0];
-        if (showIndividualDatasets) {
-            layers.push(new DataLayer('datasets', routes.geojsonDatasetsURL, new DatasetsLayer(routes)));
-        }
-    }
+
     return new OverviewMap(layers, activeLayer, defaultZoom, defaultCenter);
 }
 function getViewToggle(name) {

--- a/cubedash/static/overview.js
+++ b/cubedash/static/overview.js
@@ -278,27 +278,13 @@ var OverviewMap = /** @class */ (function (_super) {
     return OverviewMap;
 }(L.Map));
 function initPage(hasDisplayableData, showIndividualDatasets, routes, regionData, footprintData, defaultZoom, defaultCenter) {
-    var layers = [];
-    var activeLayer = null;
-    if (showIndividualDatasets) {
-      layers.push(
-        new DataLayer(
-          "datasets",
-          routes.geojsonDatasetsURL,
-          new DatasetsLayer(routes)
-        )
-      );
-    }
-        var footprint = new DataLayer('footprint', routes.geojsonFootprintURL, new FootprintLayer(footprintData, !regionData), footprintData);
-        if (regionData) {
-            layers.push(new DataLayer('regions', routes.geojsonRegionsURL, new RegionsLayer(regionData, routes), regionData, [footprint]));
-        }
-        else {
-            layers.push(footprint);
-        }
-        activeLayer = layers[0];
-
-    return new OverviewMap(layers, activeLayer, defaultZoom, defaultCenter);
+  var layers = [];
+  var activeLayer = null;
+  if (hasDisplayableData) {
+      layers.push(new DataLayer('datasets', routes.geojsonDatasetsURL, new DatasetsLayer(routes)));
+      activeLayer = layers[0];
+  }
+  return new OverviewMap(layers, activeLayer, defaultZoom, defaultCenter);
 }
 function getViewToggle(name) {
     var el = document.querySelector('input[name="map_display_view"][value="' + name + '"]');

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -554,8 +554,8 @@ class SummaryStore:
         insert into cubedash.region (dataset_type_ref, region_code, footprint, count)
             select srid_groups.dataset_type_ref,
                    coalesce(srid_groups.region_code, '')                          as region_code,
-                   ST_SimplifyPreserveTopology(
-                           ST_Union(ST_Buffer(srid_groups.footprint, 0)), 0.0001) as footprint,
+                   ST_ShiftLongitude(ST_SimplifyPreserveTopology(
+                           ST_Union(ST_Buffer(srid_groups.footprint, 0)), 0.1)) as footprint,
                    sum(srid_groups.count)                                         as count
             from srid_groups
             group by srid_groups.dataset_type_ref, srid_groups.region_code

--- a/cubedash/templates/layout/base.html
+++ b/cubedash/templates/layout/base.html
@@ -93,7 +93,7 @@
     <div id="quiet-page-errors"></div>
 </footer>
 
-<script src="{{ url_for('static', filename='leaflet-1.7.1/leaflet.js') }}"></script>
+<script src="{{ url_for('static', filename='leaflet-1.7.1/leaflet-src.js') }}"></script>
 <script src="{{ url_for('static', filename='leaflet-groupedlayercontrol/leaflet.groupedlayercontrol.js') }}"></script>
 
 {% if sentry_public_dsn %}

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="panel odd info-panel">
                     {% if have_displayable_data %}
-                        <div>
+                        <div style="display:none;">
                             {# Show regions if available, otherwise a plain footprint #}
                             {% if product_region_info %}
                                 <label>
@@ -54,6 +54,7 @@
                             <input type="radio"
                                    name="map_display_view"
                                    value="datasets"
+                                   checked="checked"
                                    {% if not show_individual_datasets %}disabled="disabled"{% endif %}
                                    title="Show individual datasets">Datasets</label>
                         </div>


### PR DESCRIPTION
- Hides ability to show region
- Fixes on leaflet the anti meridian issue (however, the cause of regions looping the map doesn't come from datacube-explorer, so the datasets is the only on-the-fly generates AOI which is why I can fix that here). - This fix comes with edits from https://github.com/briannaAndCo/Leaflet.Antimeridian/tree/master/src
- Increase simplify topology of AOI generation 